### PR TITLE
Auxiliar node initial version

### DIFF
--- a/device_control/CMakeLists.txt
+++ b/device_control/CMakeLists.txt
@@ -32,15 +32,23 @@ include_directories(include)
 add_library(${PROJECT_NAME} SHARED
   src/device_control/ControlledLifecycleNode.cpp
   src/device_control/ControllerNode.cpp
+  src/device_control/AuxiliarNode.cpp
 )
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+
+add_executable(auxiliar_main src/auxiliar_main.cpp)
+ament_target_dependencies(auxiliar_main ${dependencies})
+target_link_libraries(auxiliar_main ${PROJECT_NAME})
 
 install(DIRECTORY include/
   DESTINATION include/
 )
 
+install(DIRECTORY config launch DESTINATION share/${PROJECT_NAME})
+
 install(TARGETS
   ${PROJECT_NAME}
+  auxiliar_main
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/device_control/config/config_example.yaml
+++ b/device_control/config/config_example.yaml
@@ -1,0 +1,6 @@
+example_device_1:
+  ros__parameters:
+    topics:
+      - system1
+      - system1/sensor1
+      - system1/sensor2

--- a/device_control/include/device_control/AuxiliarNode.hpp
+++ b/device_control/include/device_control/AuxiliarNode.hpp
@@ -1,0 +1,42 @@
+// Copyright 2021 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DEVICE_CONTROL__AUXILIARNODE_HPP_
+#define DEVICE_CONTROL__AUXILIARNODE_HPP_
+
+#include "device_control/ControlledLifecycleNode.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+namespace device_control
+{
+class AuxiliarNode : public ControlledLifecycleNode
+{
+public:
+  explicit AuxiliarNode(const std::string & system_id);
+
+protected:
+  using CallbackReturnT =
+    rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+  CallbackReturnT on_configure(const rclcpp_lifecycle::State & state);
+
+  void control_start(const device_control_msgs::msg::Control::SharedPtr msg) final;
+  void control_stop(const device_control_msgs::msg::Control::SharedPtr msg) final;
+};
+
+}  // namespace device_control
+
+#endif  // DEVICE_CONTROL__AUXILIARNODE_HPP_

--- a/device_control/launch/auxiliar.launch.py
+++ b/device_control/launch/auxiliar.launch.py
@@ -1,0 +1,40 @@
+# Copyright 2021 Intelligent Robotics Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
+from launch.actions import DeclareLaunchArgument
+
+def generate_launch_description():
+    pkg_dir = get_package_share_directory('device_control')
+    params_file = LaunchConfiguration('params_file')
+
+    return LaunchDescription([
+        DeclareLaunchArgument(
+          'params_file',
+          default_value=os.path.join(pkg_dir, 'config', 'config_example.yaml'),
+          description='Full path to the ROS2 parameters file to use for auxiliar node'),
+        Node(
+            package='device_control',
+            namespace='',
+            executable='auxiliar_main',
+            name='example_device_1',
+            parameters=[params_file]
+        )
+    ])

--- a/device_control/src/auxiliar_main.cpp
+++ b/device_control/src/auxiliar_main.cpp
@@ -1,0 +1,34 @@
+// Copyright 2021 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <memory>
+
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "device_control/AuxiliarNode.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<device_control::AuxiliarNode>("default");
+  node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  rclcpp::spin(node->get_node_base_interface());
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/device_control/src/device_control/AuxiliarNode.cpp
+++ b/device_control/src/device_control/AuxiliarNode.cpp
@@ -1,0 +1,65 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "device_control/AuxiliarNode.hpp"
+
+namespace device_control
+{
+
+using std::placeholders::_1;
+
+AuxiliarNode::AuxiliarNode(const std::string & system_id)
+: ControlledLifecycleNode(system_id)
+{
+  declare_parameter("topics");
+}
+
+using CallbackReturnT =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+CallbackReturnT
+AuxiliarNode::on_configure(const rclcpp_lifecycle::State & state)
+{
+  auto topics_params = get_parameter("topics").as_string_array();
+  topics_ = std::set<std::string>(topics_params.begin(), topics_params.end());
+  
+  return ControlledLifecycleNode::on_configure(state);
+}
+
+void
+AuxiliarNode::control_start(const device_control_msgs::msg::Control::SharedPtr msg)
+{
+  (void)msg;
+  RCLCPP_INFO_STREAM(get_logger(), "System [" << get_name() << "] started with topics:");
+  for (const auto & topic : topics_) {
+    RCLCPP_INFO_STREAM(get_logger(), "  - [" << topic << "]");
+  }
+}
+
+void
+AuxiliarNode::control_stop(const device_control_msgs::msg::Control::SharedPtr msg)
+{
+  (void)msg;
+  RCLCPP_INFO_STREAM(get_logger(), "System [" << get_name() << "] stopped");
+}
+
+}  // namespace device_control

--- a/device_control/test/CMakeLists.txt
+++ b/device_control/test/CMakeLists.txt
@@ -1,3 +1,7 @@
 ament_add_gtest(test_control test_control.cpp)
 target_link_libraries(test_control ${PROJECT_NAME})
 ament_target_dependencies(test_control ${dependencies})
+
+ament_add_gtest(test_auxiliar test_auxiliar.cpp)
+target_link_libraries(test_auxiliar ${PROJECT_NAME})
+ament_target_dependencies(test_auxiliar ${dependencies})

--- a/device_control/test/test_auxiliar.cpp
+++ b/device_control/test/test_auxiliar.cpp
@@ -1,0 +1,91 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <memory>
+#include <set>
+#include <vector>
+
+#include "std_msgs/msg/string.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "device_control_msgs/msg/control.hpp"
+#include "device_control_msgs/msg/device_info.hpp"
+#include "device_control/ControlledLifecycleNode.hpp"
+#include "device_control/ControllerNode.hpp"
+#include "device_control/AuxiliarNode.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "gtest/gtest.h"
+
+
+TEST(Controltests, test_sync)
+{
+  auto node_1 = std::make_shared<device_control::AuxiliarNode>("example_device_1");
+  auto control_node = std::make_shared<device_control::ControllerNode>();
+
+  std::vector<device_control_msgs::msg::DeviceInfo> env_infos;
+  auto env_sub = control_node->create_subscription<device_control_msgs::msg::DeviceInfo>(
+    "device_environment",
+    rclcpp::QoS(1000).reliable().transient_local().keep_all(),
+    [&env_infos](const device_control_msgs::msg::DeviceInfo::SharedPtr msg) {
+      env_infos.push_back(*msg);
+    });
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(node_1->get_node_base_interface());
+  executor.add_node(control_node);
+
+  ASSERT_TRUE(env_infos.empty());
+
+  auto param = rclcpp::Parameter(
+    "topics", std::vector<std::string> {
+      "system1",
+      "system1/sensor1",
+      "system1/sensor2"});
+
+  node_1->set_parameter(param);
+
+
+  node_1->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  auto start = control_node->now();
+  while ((control_node->now() - start).seconds() < 0.2) {
+    executor.spin_some();
+  }
+
+  ASSERT_FALSE(env_infos.empty());
+  ASSERT_EQ(env_infos.size(), 1u);
+  ASSERT_EQ(env_infos[0].device_source, "example_device_1");
+  ASSERT_EQ(env_infos[0].topics.size(), 3u);
+  ASSERT_EQ(env_infos[0].topics[0], "system1");
+  ASSERT_EQ(env_infos[0].topics[1], "system1/sensor1");
+  ASSERT_EQ(env_infos[0].topics[2], "system1/sensor2");
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+
+  auto result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+  rclcpp::Rate(1).sleep();
+  return result;
+}


### PR DESCRIPTION
Hi,

This PR contains an option for devices that do not use `ControlledLifecycleNode` and still want to use `rqt_device_control` to record its outputs. 

You only have to create a param file declaring the output topics suitable to be recorded, like this:

```
example_device_1:
  ros__parameters:
    topics:
      - system1
      - system1/sensor1
      - system1/sensor2
```

and launch it, specifying this file:

```
ros2 launch device_control auxiliar.launch.py params_file:=device_control/config/config_example.yaml
```

I hope it helps!!

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>